### PR TITLE
Mixed bag of bug fixes and features

### DIFF
--- a/hexmap.inx
+++ b/hexmap.inx
@@ -25,7 +25,7 @@
             <param name="bricks" type="bool" gui-text="Bricks">false</param>
             <param name="squarebricks" type="bool" gui-text="Force Square Bricks">false</param>
             <param name="rotate" type="bool" gui-text="Rotate">false</param>
-            <param name="halfhexes" type="bool" gui-text="Half hexes at top and bottom">false</param>
+            <param name="halfhexes" type="bool" gui-text="Half hexes at top and bottom">true</param>
             <param name="xshift" type="bool" gui-text="Shift grid to side and wrap">false</param>
             <param name="firstcoldown" type="bool" gui-text="First column half-hex down">false</param>
         </page>

--- a/hexmap.inx
+++ b/hexmap.inx
@@ -11,9 +11,9 @@
                <option value="pt">pt</option>
                <option value="px">px</option>
             </param>
-            <param name="cols" type="int" gui-text="Columns" min="1" max="1000000">10</param>
-            <param name="rows" type="int" gui-text="Rows" min="1" max="1000000">10</param>
-            <param name="hexsize" type="float" min="0" max="9999" precision="2" gui-text="Hex Size (optional)" />
+            <param name="cols" type="int" gui-text="Columns" min="1" max="1000000">7</param>
+            <param name="rows" type="int" gui-text="Rows" min="1" max="1000000">7</param>
+            <param name="hexsize" type="float" min="0" max="9999" precision="2" gui-text="Hex Size (optional)">30</param>
             <param name="orientation" type="optiongroup" appearance="combo" gui-text="Hex Size Orientation">
                <option value="flattoflat">Flat to Flat</option>
                <option value="peektopeek">Peek to Peek</option>

--- a/hexmap.inx
+++ b/hexmap.inx
@@ -18,7 +18,7 @@
                <option value="flattoflat">Flat to Flat</option>
                <option value="peektopeek">Peek to Peek</option>
             </param>
-            <param name="strokewidth" type="float" min="0.0" max="9999.0" gui-text="Stroke Width">1.0</param>
+            <param name="strokewidth" type="float" min="0.0" max="9999.0" precision="3" gui-text="Stroke Width">1.000</param>
             <param name="verticesize" type="float" min="0.0" max="50.0" gui-text="Size of vertices (%)">10.0</param>
         </page>
         <page name="page_2" gui-text="Style">

--- a/hexmap.inx
+++ b/hexmap.inx
@@ -30,6 +30,8 @@
             <param name="firstcoldown" type="bool" gui-text="First column half-hex down">false</param>
         </page>
         <page name="page_3" gui-text="Coords">
+            <param name="fontfamily" type="string" gui-text="Font Family">sans-serif</param>
+            <param name="fontsize" type="float" gui-text="Font Size" min="0" max="10000" precision="1">10.0</param>
             <param name="coordseparator" type="string" gui-text="Coordinate Separator">.</param>
             <param name="coordalphacol" type="bool" gui-text="Column Alpha Coordinates">false</param>
             <param name="coordrevrow" type="bool" gui-text="Row Coordinates Reversed">false</param>

--- a/hexmap.inx
+++ b/hexmap.inx
@@ -13,7 +13,11 @@
             </param>
             <param name="cols" type="int" gui-text="Columns" min="1" max="1000000">10</param>
             <param name="rows" type="int" gui-text="Rows" min="1" max="1000000">10</param>
-            <param name="hexsize" type="float" min="0" max="9999" gui-text="Hex Size (optional)" />
+            <param name="hexsize" type="float" min="0" max="9999" precision="2" gui-text="Hex Size (optional)" />
+            <param name="orientation" type="optiongroup" appearance="combo" gui-text="Hex Size Orientation">
+               <option value="flattoflat">Flat to Flat</option>
+               <option value="peektopeek">Peek to Peek</option>
+            </param>
             <param name="strokewidth" type="float" min="0.0" max="9999.0" gui-text="Stroke Width">1.0</param>
             <param name="verticesize" type="float" min="0.0" max="50.0" gui-text="Size of vertices (%)">10.0</param>
         </page>

--- a/hexmap.py
+++ b/hexmap.py
@@ -37,7 +37,6 @@ def alphacol(c):
     r = c % 26
     return ('%c' % (r + 65)) * (int(d) + 1)
 
-COORD_SIZE_PART_OF_HEX_HEIGHT = 0.1
 COORD_YOFFSET_PART = 75
 CENTERDOT_SIZE_FACTOR = 1.1690625
 
@@ -73,6 +72,9 @@ class HexmapEffect(inkex.Effect):
                                          default = False)
         self.arg_parser.add_argument('--rotate', type = inkex.Boolean,
                                          default = False)
+        self.arg_parser.add_argument("--fontfamily", default='sans-serif')
+        self.arg_parser.add_argument('--fontsize', type = float,
+                                         default = 10.0)
         self.arg_parser.add_argument('--coordseparator', default = '')
         self.arg_parser.add_argument('--layersingroup', type = inkex.Boolean,
                                          default = False,
@@ -188,8 +190,8 @@ class HexmapEffect(inkex.Effect):
         text = etree.Element('text')
         text.set('x', str(p.x + self.xoffset))
         text.set('y', str(p.y + self.yoffset))
-        style = ('text-align:center;text-anchor:%s;font-size:%fpt'
-                 % (anchor, self.coordsize))
+        style = ('text-align:center;text-anchor:%s;font-family:"%s";font-size:%fpt;'
+                 % (anchor, self.options.fontfamily, self.options.fontsize / 3.78))
         text.set('style', style)
         text.text = coord
         return text
@@ -329,9 +331,6 @@ class HexmapEffect(inkex.Effect):
         hexes_height = hex_height * hex_rows
         hexes_width = hex_width * 0.75 * cols + hex_width * 0.25
 
-        self.coordsize = hex_height * COORD_SIZE_PART_OF_HEX_HEIGHT
-        if self.coordsize > 1.0:
-            self.coordsize = round(self.coordsize)
         self.centerdotsize = self.stroke_width * CENTERDOT_SIZE_FACTOR
         self.circlesize = hex_height / 2
 

--- a/hexmap.py
+++ b/hexmap.py
@@ -59,6 +59,7 @@ class HexmapEffect(inkex.Effect):
         self.arg_parser.add_argument('--rows', type = int, default = '10',
                                          help = 'Number of columns')
         self.arg_parser.add_argument('--hexsize', type = float, default = 0.0)
+        self.arg_parser.add_argument('--orientation', default = 'flattoflat')
         self.arg_parser.add_argument('--strokewidth', type = float,
                                          default = 1.0)
         self.arg_parser.add_argument('--coordrows', type = int, default = '1')
@@ -315,6 +316,10 @@ class HexmapEffect(inkex.Effect):
         else:
             hex_width = width / hex_cols
             hex_height = hex_width * HEX_RATIO
+
+        if self.options.orientation == 'peektopeek':
+            hex_width = hex_width * HEX_RATIO
+            hex_height = hex_height * HEX_RATIO
 
         # square bricks workaround
         if bricks and squarebricks:

--- a/hexmap.py
+++ b/hexmap.py
@@ -362,7 +362,8 @@ class HexmapEffect(inkex.Effect):
                         anchor = 'start'
                     elif xshift and col == cols:
                         anchor = 'end'
-                    coord = self.svg_coord(cc, col, row, cols, rows, anchor)
+                    if not (halves and coldown and row == rows-1):
+                        coord = self.svg_coord(cc, col, row, cols, rows, anchor)
                     if coord != None:
                         hexcoords.append(coord)
                 if (hexdots is not None


### PR DESCRIPTION
Bug fixes:
- [1] Fix errant coordinates when halves are enabled
- [2] Allow greater strokewidth precision due to inches as a unit

Convenience feature:
- [3] Allow peek-to-peek sizing
- [4] Make coordinates more configurable

Better? defaults:
- [5] Half hexes at top and bottom enabled by default (seems to me most practical uses would probably want this)
- [6] Add hex grid default that fits on A4 page

With regard to [4] there's this 3.78 factor which I can't explain yet? any clue?

Please do thoroughly check my work before committing...


